### PR TITLE
Improve Average Calculations

### DIFF
--- a/bucket/window.go
+++ b/bucket/window.go
@@ -6,6 +6,9 @@ import (
 )
 
 const WindowSize = 1024
+const EmptyValue = math.MaxFloat64
+
+type mapFunc func(idx int, b Interface, prev float64) float64
 
 type Window struct {
 	sync.RWMutex
@@ -17,6 +20,10 @@ type Window struct {
 	cumSum float64
 
 	last float64
+}
+
+type Averages struct {
+	EWMA1, EWMA5, EWMA10 float64
 }
 
 func NewWindow(size int) *Window {
@@ -32,6 +39,10 @@ func NewWindow(size int) *Window {
 	return w
 }
 
+func (w *Window) Index(offset int) int {
+	return (w.head + offset) % w.size
+}
+
 func (w *Window) Push(b Interface) {
 	w.Lock()
 	defer w.Unlock()
@@ -42,20 +53,32 @@ func (w *Window) Push(b Interface) {
 	}
 
 	w.buckets[w.head] = NewFixed(b)
-	w.head = (w.head + 1) % w.size
+	w.head = w.Index(1)
 }
 
-func (w *Window) Count() []float64 {
-	return w.mapFloat(func(b Interface) float64 {
-		return b.Freq()
-	})
-}
+func (w *Window) Count() []float64        { return w.mapFloat(w._count) }
+func (w *Window) CountAverages() Averages { return w.averages(w._count, false) }
 
-func (w *Window) Sum() []float64 {
-	return w.mapFloat(func(b Interface) float64 {
-		return b.Sum()
-	})
-}
+func (w *Window) Unique() []float64        { return w.mapFloat(w._unique) }
+func (w *Window) UniqueAverages() Averages { return w.averages(w._unique, false) }
+
+func (w *Window) UniquePercent() []float64        { return w.mapFloat(w._uniquePercent) }
+func (w *Window) UniquePercentAverages() Averages { return w.averages(w._uniquePercent, true) }
+
+func (w *Window) Sum() []float64        { return w.mapFloat(w._sum) }
+func (w *Window) SumAverages() Averages { return w.averages(w._sum, false) }
+
+func (w *Window) Median() []float64        { return w.mapFloat(w._median) }
+func (w *Window) MedianAverages() Averages { return w.averages(w._median, true) }
+
+func (w *Window) P75() []float64        { return w.mapFloat(w._p75) }
+func (w *Window) P75Averages() Averages { return w.averages(w._p75, true) }
+
+func (w *Window) P95() []float64        { return w.mapFloat(w._p95) }
+func (w *Window) P95Averages() Averages { return w.averages(w._p95, true) }
+
+func (w *Window) Last() []float64        { return w.mapFloat(w._last) }
+func (w *Window) LastAverages() Averages { return w.averages(w._last, true) }
 
 func (w *Window) CumSum() []float64 {
 	sums := w.Sum()
@@ -67,85 +90,102 @@ func (w *Window) CumSum() []float64 {
 	return sums
 }
 
-func (w *Window) Unique() []float64 {
-	return w.mapFloat(func(b Interface) float64 {
-		return b.Unique()
-	})
-}
-
-func (w *Window) Mean() []float64 {
-	return w.mapFloat(func(b Interface) float64 {
-		return b.Mean()
-	})
-}
-
-func (w *Window) Median() []float64 {
-	return w.mapFloat(func(b Interface) float64 {
-		return b.Median()
-	})
-}
-
-func (w *Window) P75() []float64 {
-	return w.mapFloat(func(b Interface) float64 {
-		return b.P75()
-	})
-}
-
-func (w *Window) P95() []float64 {
-	return w.mapFloat(func(b Interface) float64 {
-		return b.P95()
-	})
-}
-
-func (w *Window) P99() []float64 {
-	return w.mapFloat(func(b Interface) float64 {
-		return b.P99()
-	})
-}
-
-func (w *Window) UniquePercent() []float64 {
-	return w.mapFloat(func(b Interface) float64 {
-		ct := b.Freq()
-		if ct == 0 {
-			return 0.0
-		}
-		return 100.0 * b.Unique() / ct
-	})
-}
-
-func (w *Window) Last() []float64 {
-	lasts := w.mapFloat(func(b Interface) float64 {
-		if b.Freq() == 0 {
-			return math.MaxFloat64
-		}
-		return b.Last()
-	})
-
-	if lasts[0] == math.MaxFloat64 {
-		w.RLock()
-		lasts[0] = w.last
-		w.RUnlock()
-	}
-
-	for i := 1; i < w.size; i++ {
-		if lasts[i] == math.MaxFloat64 {
-			lasts[i] = lasts[i-1]
-		}
-	}
-
-	return lasts
-}
-
-func (w *Window) mapFloat(f func(b Interface) float64) []float64 {
+func (w *Window) mapFloat(f mapFunc) []float64 {
 	w.RLock()
 	defer w.RUnlock()
 
 	vals := make([]float64, w.size)
 
+	prev := EmptyValue
 	for i := 0; i < w.size; i++ {
-		idx := (w.head + i) % w.size
-		vals[i] = f(w.buckets[idx])
+		vals[i] = f(i, w.buckets[w.Index(i)], prev)
+		prev = vals[i]
 	}
 
 	return vals
+}
+
+func (w *Window) mapEWMA(f mapFunc, fill bool) []float64 {
+	w.RLock()
+	defer w.RUnlock()
+
+	if w.size == 0 {
+		return []float64{}
+	}
+
+	i := 0
+	for ; i < w.size; i++ {
+		if w.buckets[w.Index(i)].Freq() > 0 {
+			break
+		}
+	}
+
+	vals := make([]float64, w.size-i)
+	prev := EmptyValue
+
+	for i, j := i, 0; i < w.size; i, j = i+1, j+1 {
+		b := w.buckets[w.Index(i)]
+
+		if b.Freq() == 0 && fill && prev != EmptyValue {
+			vals[j] = prev
+			continue
+		}
+
+		vals[j] = f(i, b, prev)
+		prev = vals[j]
+	}
+
+	return vals
+}
+
+// based off: https://en.wikipedia.org/wiki/Moving_average#Application_to_measuring_computer_performance
+func (w *Window) ewma(data []float64, interval float64) float64 {
+	ct := len(data)
+	if ct == 0 {
+		return 0.0
+	}
+
+	W := float64(ct) / 60.0 // How long is the data relevant (in minutes)
+	a := math.Exp(-1.0 / (W * interval))
+
+	y := data[0]
+	for i := 1; i < ct; i++ {
+		y = data[i] + a*(y-data[i])
+	}
+
+	return y
+}
+
+func (w *Window) averages(f mapFunc, fill bool) Averages {
+	data := w.mapEWMA(f, fill)
+	return Averages{
+		EWMA1:  w.ewma(data, 1),
+		EWMA5:  w.ewma(data, 5),
+		EWMA10: w.ewma(data, 10),
+	}
+}
+
+func (w *Window) _count(_ int, b Interface, _ float64) float64  { return b.Freq() }
+func (w *Window) _unique(_ int, b Interface, _ float64) float64 { return b.Unique() }
+func (w *Window) _sum(_ int, b Interface, _ float64) float64    { return b.Sum() }
+func (w *Window) _median(_ int, b Interface, _ float64) float64 { return b.Median() }
+func (w *Window) _p75(_ int, b Interface, _ float64) float64    { return b.P75() }
+func (w *Window) _p95(_ int, b Interface, _ float64) float64    { return b.P95() }
+
+func (w *Window) _uniquePercent(_ int, b Interface, _ float64) float64 {
+	ct := b.Freq()
+	if ct == 0 {
+		return ct
+	}
+	return 100.0 * b.Unique() / ct
+}
+
+func (w *Window) _last(i int, b Interface, prev float64) float64 {
+	if b.Freq() == 0 {
+		if i == 0 {
+			return w.last
+		}
+		return prev
+	}
+	return b.Last()
 }

--- a/views/set.go
+++ b/views/set.go
@@ -27,24 +27,24 @@ func newSet(w *bucket.MetricWindow, prev *termui.Row) *plotSet {
 	switch w.Metric.Type {
 	case datagram.Gauge:
 		s.plots = []*plot{
-			newPlot("Gauge Value", color, w.Last, true),
+			newPlot("Gauge Value", color, w.Last, w.LastAverages),
 		}
 	case datagram.Counter:
 		s.plots = []*plot{
-			newPlot("Count", color, w.Sum, true),
-			newPlot("Cumulative Count", color, w.CumSum, false),
+			newPlot("Count", color, w.Sum, w.SumAverages),
+			newPlot("Cumulative Count", color, w.CumSum, nil),
 		}
 	case datagram.Histogram, datagram.Timer:
 		s.plots = []*plot{
-			newPlot("Count", color, w.Count, true),
-			newPlot("Median", color, w.Median, true),
-			newPlot("95th Percentile", color, w.P95, true),
-			newPlot("99th Percentile", color, w.P99, true),
+			newPlot("Count", color, w.Count, w.CountAverages),
+			newPlot("Median", color, w.Median, w.MedianAverages),
+			newPlot("75th Percentile", color, w.P75, w.P75Averages),
+			newPlot("95th Percentile", color, w.P75, w.P95Averages),
 		}
 	case datagram.Set:
 		s.plots = []*plot{
-			newPlot("Unique Count", color, w.Unique, true),
-			newPlot("Percent Unique", color, w.UniquePercent, true),
+			newPlot("Unique Count", color, w.Unique, w.UniqueAverages),
+			newPlot("Percent Unique", color, w.UniquePercent, w.UniquePercentAverages),
 		}
 	}
 


### PR DESCRIPTION
EWMAs were originally being calculated including all data points, specifically the 600 dummy buckets at initialization. This resulted in the 5m and 10m EWMAs to be particularly off at the start.

This patch makes these calculations smarter and only start from the first non-empty bucket. It also (for the metrics where it is appropriate) fills in buckets without any points with the previous bucket's value. This has a similar effect of not diminishing the averages while still preserving the decay across the window.