### PR TITLE
Scroll Metric List

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# statstee
+
+_The Proxyless Command Line UI for StatsD Metrics_

--- a/example/statter/main.go
+++ b/example/statter/main.go
@@ -17,11 +17,11 @@ func main() {
 	gs.SetNamespace("statter")
 
 	go histogram(gs)
+
 	go timer(gs)
 	go count(gs)
 	go gauge(gs)
 	go set(gs)
-
 	waitForSignal()
 }
 

--- a/views/double-buffer.go
+++ b/views/double-buffer.go
@@ -3,8 +3,6 @@ package views
 import (
 	"sync"
 
-	"log"
-
 	"github.com/gizak/termui"
 	"github.com/rodaine/statstee/router"
 )
@@ -30,18 +28,16 @@ func (db *doubleBuffer) draw() {
 }
 
 func (db *doubleBuffer) lazy() {
-	log.Println("lazy")
 	go db.update(false)
 }
 
 func (db *doubleBuffer) update(force bool) {
 	db.Lock()
-	log.Println("updating")
+
 	db.next.update(false)
 	db.next.grid.Width = termui.TermWidth()
 	db.next.grid.Align()
 	db.current, db.next = db.next, db.current
 
-	log.Println("updated")
 	db.Unlock()
 }


### PR DESCRIPTION
If the metric list grows beyond its bounds, the existing UI does not update to scroll to reveal the selected metric if the cursor moves below or above the border. This change fixes just that. It also includes a `current/total` in the header to let the user know if there is more beyond the borders.