### PR TITLE
Startup Errors Now Print

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cover.*
 dist/
 vendor/
+*.log

--- a/views/loop.go
+++ b/views/loop.go
@@ -1,9 +1,13 @@
 package views
 
 import (
+	"sync"
+
 	"github.com/gizak/termui"
 	"github.com/rodaine/statstee/router"
 )
+
+var quitOnce = &sync.Once{}
 
 func Loop(r *router.Router) (err error) {
 	if err = termui.Init(); err != nil {
@@ -21,7 +25,7 @@ func Loop(r *router.Router) (err error) {
 }
 
 func Quit() {
-	termui.StopLoop()
+	quitOnce.Do(termui.StopLoop)
 }
 
 func registerHandlers(r *router.Router, db *doubleBuffer) {


### PR DESCRIPTION
Startup errors, typically related to pcap (not running as sudo for access) were being swallowed. These changes ensure they always print.

This also ensures we exit with nonzero.