### PR TITLE
Stop flickering by stop syncing

### DIFF
--- a/views/double-buffer.go
+++ b/views/double-buffer.go
@@ -1,30 +1,49 @@
 package views
 
 import (
+	"fmt"
+	"log"
 	"sync"
 
 	"github.com/gizak/termui"
 	"github.com/rodaine/statstee/router"
 )
 
+const (
+	minWidth  = 78
+	minHeight = 20
+)
+
 type doubleBuffer struct {
 	sync.RWMutex
+	width, height int
 	current, next *display
 }
 
 func newBuffer(r *router.Router) *doubleBuffer {
-	return &doubleBuffer{
+	db := &doubleBuffer{
 		current: newDisplay(r),
 		next:    newDisplay(r),
 	}
+
+	db.dimSync()
+	db.current.update()
+	db.next.update()
+
+	return db
 }
 
 func (db *doubleBuffer) draw() {
+	var b termui.Bufferer
 	db.RLock()
-	g := db.current.grid
-	db.RUnlock()
+	if db.tooSmall() {
+		b = db.smallView()
+	} else {
+		b = db.current.grid
+	}
 
-	termui.Render(g)
+	termui.Render(b)
+	db.RUnlock()
 }
 
 func (db *doubleBuffer) lazy() {
@@ -33,11 +52,56 @@ func (db *doubleBuffer) lazy() {
 
 func (db *doubleBuffer) update(force bool) {
 	db.Lock()
+	defer db.Unlock()
 
-	db.next.update(false)
-	db.next.grid.Width = termui.TermWidth()
+	if force {
+		db.dimSync()
+	}
+
+	if db.tooSmall() {
+		return
+	}
+
+	db.next.update()
 	db.next.grid.Align()
 	db.current, db.next = db.next, db.current
+}
 
-	db.Unlock()
+func (db *doubleBuffer) dimSync() {
+	w, h := termui.TermWidth(), termui.TermHeight()
+
+	db.width, db.height = w, h
+	db.current.dimSync(w, h)
+	db.next.dimSync(w, h)
+}
+
+func (db *doubleBuffer) smallView() *termui.Par {
+	w := db.width
+	h := db.height
+
+	if w < 1 {
+		w = 1
+	}
+
+	if h < 1 {
+		h = 1
+	}
+
+	txt := fmt.Sprintf("SCREEN TOO SMALL\nCURRENT: %dx%d\nMIN: %dx%d", db.width, db.height, minWidth, minHeight)
+	log.Println(txt)
+
+	v := termui.NewPar(txt)
+	v.Border = false
+	v.Width = w
+	v.Height = h
+
+	v.Bg = termui.ColorRed
+	v.TextBgColor = termui.ColorRed
+	v.TextFgColor = termui.ColorBlack
+
+	return v
+}
+
+func (db *doubleBuffer) tooSmall() bool {
+	return db.width < minWidth || db.height < minHeight
 }

--- a/views/plot.go
+++ b/views/plot.go
@@ -1,9 +1,8 @@
 package views
 
 import (
-	"time"
-
 	"fmt"
+	"time"
 
 	"github.com/gizak/termui"
 	"github.com/rodaine/statstee/bucket"

--- a/views/router.go
+++ b/views/router.go
@@ -26,6 +26,7 @@ const (
 type routerView struct {
 	offset int
 	l      *termui.List
+	height int
 }
 
 func newRouterView(r *router.Router) *routerView {
@@ -38,7 +39,6 @@ func newRouterView(r *router.Router) *routerView {
 	v.l.BorderFg = borderColor
 	v.l.BorderBg = borderColor
 
-	v.update(r)
 	return v
 }
 
@@ -46,7 +46,7 @@ func (v *routerView) update(r *router.Router) {
 	s := r.Selected()
 	ms := r.Metrics()
 
-	v.l.Height = termui.TermHeight()
+	v.l.Height = v.height
 
 	items := make([]string, len(ms))
 	selIdx := 0

--- a/views/set.go
+++ b/views/set.go
@@ -16,6 +16,7 @@ type plotSet struct {
 	plots  []*plot
 	header *termui.Par
 	row    *termui.Row
+	height int
 }
 
 func newSet(w *bucket.MetricWindow, prev *termui.Row) *plotSet {
@@ -48,29 +49,20 @@ func newSet(w *bucket.MetricWindow, prev *termui.Row) *plotSet {
 		}
 	}
 
-	s.row = termui.NewCol(dataWidth, 0, s.items()...)
-	if prev != nil {
-		s.row.Width = prev.Width
-		s.row.Height = prev.Height
-		s.row.X = prev.X
-		s.row.Y = prev.Y
-	}
-
-	s.update()
-
+	s.row = termui.NewCol(dataGridSpan, 0, s.items()...)
 	return s
 }
 
 func (s *plotSet) update() {
-	ht := termui.TermHeight() - 1
+	ht := s.height - 1
 	ct := len(s.plots)
 
 	for _, p := range s.plots {
-		p.update()
-
 		p.lc.Height = ht / ct
 		ht -= p.lc.Height
 		ct--
+
+		p.update()
 	}
 
 }


### PR DESCRIPTION
On slower terminals (SSH or locally, zoomed way out), rendering of the UI would flicker regularly. This was a result of excessive calls to `termui.TermHeight()` and `termui.TermWidth()` which internally calls `termbox.Sync()`. From the [docs](https://godoc.org/github.com/nsf/termbox-go#Sync): 

> Sync forces a complete resync between the termbox and a terminal, it may not be visually pretty though.

To prevent this, the width and height of the terminal is only requested at initial startup and in the event of a terminal resize. Great success!