### PR TITLE
Fix PCAP settings for Linux machines

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-GO15VENDOREXPERIMENT=1
+export GO15VENDOREXPERIMENT=1
 script/require-glide
 
 mkdir -p dist

--- a/script/test
+++ b/script/test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-GO15VENDOREXPERIMENT=1
+export GO15VENDOREXPERIMENT=1
 cd $(dirname "$0")/..
 
 $(dirname "$0")/require-glide

--- a/statstee.go
+++ b/statstee.go
@@ -77,6 +77,7 @@ func captureMetrics(r *router.Router) {
 
 func fatalIfError(err error) {
 	if err != nil {
+		log.Println(err)
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Setting the buffer size when setting up the PCAP sniffer causes
the listener to close immediately with an unknown error. More
investigation into why this is occuring would be useful, but for
now this allows the sniffer mode to work.

@promiseofcake This should resolve your issues.
//cc @twoism